### PR TITLE
.input -> .input-field

### DIFF
--- a/app/views/announcements/_form.html.slim
+++ b/app/views/announcements/_form.html.slim
@@ -6,22 +6,22 @@
         - @announcement.errors.full_messages.each do |message|
           li = message
 
-  .field
+  .input-field
     = f.label :title
     = f.text_field :title
-  .field
+  .input-field
     = f.label :message
     = f.text_area :message, class: 'materialize-textarea'
-  .field
+  .input-field
     = f.label :announce_at
     = f.text_field :announce_at, class: 'datetimepicker'
-  .field
+  .input-field
     = f.label :announce_icon
     = f.text_field :announce_icon
-  .field
+  .input-field
     = f.label :announce_name
     = f.text_field :announce_name
-  .field
+  .input-field
     = f.label :channel
     = f.text_field :channel
   .actions = f.submit t('views.common.create'), class: 'btn waves-effect waves-light'


### PR DESCRIPTION
[Materialize CSS Document](http://materializecss.com/forms.html) によると `.input-field` らしいので

おそらくこれによってtextareaの入力欄が入力しているテキストの行数に合わせて伸縮するようになるかと思います。